### PR TITLE
Swift 2.0 Compatibility

### DIFF
--- a/Source/UIImageEffects.swift
+++ b/Source/UIImageEffects.swift
@@ -181,13 +181,13 @@ public extension UIImage {
             CGContextTranslateCTM(effectInContext, 0, -size.height)
             CGContextDrawImage(effectInContext, imageRect, self.CGImage)
             
-            var effectInBuffer = createEffectBuffer(effectInContext)
+            var effectInBuffer = createEffectBuffer(effectInContext!)
 
             
             UIGraphicsBeginImageContextWithOptions(size, false, screenScale)
             let effectOutContext = UIGraphicsGetCurrentContext()
             
-            var effectOutBuffer = createEffectBuffer(effectOutContext)
+            var effectOutBuffer = createEffectBuffer(effectOutContext!)
             
             
             if hasBlur {


### PR DESCRIPTION
When I tried to use the class in XCode 7.1.1 with Swift 2, it threw an error until I made these changes.
